### PR TITLE
ci: bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo clippy -- -D warnings
       - run: cargo test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
             asset: gg-macos-arm64
             run_tests: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## What

Bump GitHub Actions to their Node-24-native majors to clear the Node-20 runtime deprecation. GitHub force-migrates deprecated (Node-20) actions to Node 24 on **2026-06-16**; pinning ahead avoids surprise behaviour changes.

## Bump map

| action | after |
|---|---|
| actions/checkout | v6 |
| actions/setup-go | v6 |
| actions/setup-node | v6 |
| actions/cache | v5 |
| actions/setup-java | v5 |
| actions/setup-python | v6 |
| actions/upload-artifact | v7 |
| actions/download-artifact | v8 |

upload/download bumped as a matched pair (v7 ↔ v8) so the artifact handshake stays compatible.

Part of 🎯T4 (fleet-wide Actions deprecation sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)